### PR TITLE
Limit gnutls workaround to emacs version older than 2.6.3.

### DIFF
--- a/lisp/init-package.el
+++ b/lisp/init-package.el
@@ -6,7 +6,8 @@
   (package-initialize))
 
 ;; workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341
-(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
+(when (version< emacs-version "26.3")
+  (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
 
 (defun require-package (package &optional min-version no-refresh)
   "Install given PACKAGE, optionally requiring MIN-VERSION.


### PR DESCRIPTION
The referenced bug was fixed in 2.6.3, and the workaround introduces problems
on system with old gnutls (e.g. centos 7).